### PR TITLE
QuPath import: set ROI color when path class is not used

### DIFF
--- a/QuPath.scripts/OME_XML_import.groovy
+++ b/QuPath.scripts/OME_XML_import.groovy
@@ -100,7 +100,7 @@ void setPathClassAndStroke(PathROIObject path, String className, Color color, Nu
     if (className == null) {
         // No class to set, so just set the color directly
         if (qpColor != null) {
-            path.setColorRGB()
+            path.setColorRGB(qpColor)
         }
     } else {
         def qpClass = PathClassFactory.getPathClass(className, qpColor)


### PR DESCRIPTION
I think this fixes the colors for .mld dataset 3 (```Trident01016_6_8.svs```).  Importing the OME-XML generated by ROI_Converter into QuPath should now show a bunch of cyan annotations, though some are still black (but that seems to be valid as far as I can see). 