### PR TITLE
Grading: remove ambiguous 'null' in call to PathClassFactory.getPathClass

### DIFF
--- a/QuPath.scripts/grading_workflow.groovy
+++ b/QuPath.scripts/grading_workflow.groovy
@@ -82,7 +82,7 @@ void gradingWorkflow() {
         "Grade 4"
     ]
     grades.each { grade ->
-        def qpClass = PathClassFactory.getPathClass(grade, null)
+        def qpClass = PathClassFactory.getPathClass(grade)
         classList.add(qpClass)
     }
 }


### PR DESCRIPTION
Prior to QuPath 0.2.0-m9, there was only one ```PathClassFactory.getPathClass(...)``` signature
that took two parameters.  Now there are two:

- PathClassFactory.getPathClass(String, Integer)
- PathClassFactory.getPathClass(String, String...)

Calling just ```getPathClass(String)``` will delegate to ```getPathClass(String, (Integer) null)```
internally, see:

https://github.com/qupath/qupath/blob/v0.2.0-m9/qupath-core/src/main/java/qupath/lib/objects/classes/PathClassFactory.java#L216

With this change, the grading workflow should work with 0.2.0-m5 and all later versions.