### PR TITLE
QuPath import: add an index to each ROI's display name

### DIFF
--- a/QuPath.scripts/OME_XML_import.groovy
+++ b/QuPath.scripts/OME_XML_import.groovy
@@ -76,6 +76,8 @@ factory = new ServiceFactory()
 service = factory.getInstance(OMEXMLService.class)
 OMEXMLMetadata omexml = service.createOMEXMLMetadata(xml)
 
+nameIndexes = new HashMap<String, Integer>();
+
 roiCount = omexml.getROICount()
 
 if (roiCount < 1) {
@@ -420,8 +422,11 @@ void setPathClassAndStroke(PathROIObject path, String className, Color color, Nu
         if (roi != null) {
             if (mapAnnotations["qupath:name"] != null) {
                 path.setName(mapAnnotations["qupath:name"])
-            } else if (omexml.getROIName(roiIdx) != null) {
-                path.setName(omexml.getROIName(roiIdx))
+            } else {
+                def roiName = omexml.getROIName(roiIdx);
+                if (roiName != null) {
+                    path.setName(String.format("%s #%d", roiName, getIndex(roiName)));
+                }
             }
             path.setROI(roi)
             mapAnnotations.keySet().each {
@@ -450,6 +455,16 @@ void updatePathClasses() {
             classList.add(qpClass)
         }
     }
+}
+
+Integer getIndex(String roiName) {
+    def index = nameIndexes.get(roiName);
+    if (index != null) {
+        nameIndexes.put(roiName, index + 1);
+        return index;
+    }
+    nameIndexes.put(roiName, 2);
+    return 1;
 }
 
 void chooseLineWidths() {


### PR DESCRIPTION
There are a few ways to do this; this commit is just one of the simplest.
Each ROI's name has the index (from 1) of the ROI relative to all other ROIs
with the same name, e.g.

```
ROI 002 #1
ROI 002 #2
...
ROI 002 #10000
ROI 003 #1
ROI 003 #2
...
ROI 003 #100
```

Other options are:

- keep the indexing scheme above, but for each name pad indexes to the same width (```ROI 002 #00001```, ```ROI 003 #001```)
- index relative to the whole ROI list, with or without padding (```ROI 002 #10000```, ```ROI 003 #10001```)
