### PR TITLE
Update QuPath scripts for 0.2.0-m10

### DIFF
--- a/QuPath.scripts/OME_XML_export.groovy
+++ b/QuPath.scripts/OME_XML_export.groovy
@@ -40,6 +40,7 @@ import ome.xml.model.enums.FillRule
 import ome.xml.model.primitives.Color
 import ome.xml.model.primitives.NonNegativeInteger
 import qupath.lib.common.ColorTools
+import qupath.lib.gui.dialogs.Dialogs
 import qupath.lib.gui.prefs.PathPrefs
 import qupath.lib.gui.scripting.QPEx
 import qupath.lib.objects.PathROIObject
@@ -71,7 +72,7 @@ static void setCommonProperties(Shape shape, PathROIObject path, qupath.lib.roi.
         if (path.pathClass != null) {
             packedColor = path.pathClass.color
         } else {
-            packedColor = PathPrefs.getColorDefaultAnnotations()
+            packedColor = PathPrefs.colorDefaultObjectsProperty().get()
         }
     }
     if (packedColor != null) {
@@ -101,9 +102,9 @@ static void setCommonProperties(Shape shape, PathROIObject path, qupath.lib.roi.
     // and another for detections. We'll store the stroke width on each ROI, but when loading an OME-XML
     // the stroke width of last ROI loaded will be used to set the system property.
     if (path.isAnnotation()) {
-        shape.setStrokeWidth(new Length(PathPrefs.getThickStrokeThickness(), UNITS.PIXEL))
+        shape.setStrokeWidth(new Length(PathPrefs.annotationStrokeThicknessProperty().get(), UNITS.PIXEL))
     } else if (path.isDetection()) {
-        shape.setStrokeWidth(new Length(PathPrefs.getThinStrokeThickness(), UNITS.PIXEL))
+        shape.setStrokeWidth(new Length(PathPrefs.detectionStrokeThicknessProperty().get(), UNITS.PIXEL))
     }
 
     // Note: Currently, QuPath does not allow for dashed lines
@@ -237,7 +238,6 @@ rois.eachWithIndex { PathROIObject path, int i ->
 
 ome.setStructuredAnnotations(structuredAnnotations);
 
-qupath = QPEx.getQuPath()
-file = qupath.getDialogHelper().promptToSaveFile("Choose OME-XML export location", null, null, "OME-XML", ".ome.xml")
+file = Dialogs.promptToSaveFile("Choose OME-XML export location", null, null, "OME-XML", ".ome.xml")
 xmlWriter = new XMLWriter();
 xmlWriter.writeFile(file, ome, false);

--- a/QuPath.scripts/OME_XML_export.groovy
+++ b/QuPath.scripts/OME_XML_export.groovy
@@ -40,11 +40,19 @@ import ome.xml.model.enums.FillRule
 import ome.xml.model.primitives.Color
 import ome.xml.model.primitives.NonNegativeInteger
 import qupath.lib.common.ColorTools
+import qupath.lib.common.GeneralTools
 import qupath.lib.gui.dialogs.Dialogs
 import qupath.lib.gui.prefs.PathPrefs
 import qupath.lib.gui.scripting.QPEx
 import qupath.lib.objects.PathROIObject
 import qupath.lib.roi.*
+
+// first check the version; only 0.2.0-m10 and later are supported
+version = GeneralTools.getVersion()
+versionTokens = version.split("-")
+if (!versionTokens[0].equals("0.2.0") || (versionTokens.length == 2 && Integer.parseInt(versionTokens[1].substring(1)) < 10)) {
+    throw new RuntimeException("Unsupported QuPath version: " + version)
+}
 
 ome = new OME()
 structuredAnnotations = new StructuredAnnotations()

--- a/QuPath.scripts/OME_XML_import.groovy
+++ b/QuPath.scripts/OME_XML_import.groovy
@@ -56,6 +56,7 @@ import ome.xml.model.primitives.Color
 import qupath.imagej.tools.ROIConverterIJ
 import qupath.lib.common.ColorTools
 import qupath.lib.geom.Point2
+import qupath.lib.gui.dialogs.Dialogs
 import qupath.lib.gui.dialogs.ParameterPanelFX
 import qupath.lib.gui.prefs.PathPrefs
 import qupath.lib.gui.scripting.QPEx
@@ -69,7 +70,7 @@ import qupath.lib.regions.ImagePlane
 import qupath.lib.roi.*
 
 qupath = QPEx.getQuPath()
-file = qupath.getDialogHelper().promptForFile("Choose an OME-XML to import", null, "image.ome.xml", ".ome.xml")
+file = Dialogs.promptForFile("Choose an OME-XML to import", null, "image.ome.xml", ".ome.xml")
 xml = file.readLines().join("\n")
 
 factory = new ServiceFactory()


### PR DESCRIPTION
See #14.

As noted in the commit messages, the import script should remain backwards compatible.  I have tested with m5, m9, and m10 and not seen any issues.

The export script, however, will now only work with m10 due to changes in the annotation/detection stroke thickness properties (https://github.com/qupath/qupath/commit/8e8fdbf).  If <=m9 support is still needed, do not merge this as is.