### PR TITLE
Update blitz dependency to 5.5.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ configurations.all {
 }
 
 dependencies {
-    implementation 'org.openmicroscopy:omero-blitz:5.5.6'
+    implementation 'org.openmicroscopy:omero-blitz:5.5.8'
     implementation 'com.zeroc:icegrid:3.6.4'
     implementation 'org.slf4j:slf4j-api:1.7.30'
     implementation 'org.slf4j:log4j-over-slf4j:1.7.30'


### PR DESCRIPTION
Solves this exception when running ```bin/ome-omero-roitool import```:

```
Exception in thread "main" picocli.CommandLine$ExecutionException: Error while calling command (com.glencoesoftware.roitool.Import@2d6eabae): Ice.SocketException
    error = 0
	at picocli.CommandLine.executeUserObject(CommandLine.java:1862)
	at picocli.CommandLine.access$1100(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2255)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2249)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2213)
	at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:2073)
	at picocli.CommandLine.parseWithHandlers(CommandLine.java:2454)
	at picocli.CommandLine.parseWithHandler(CommandLine.java:2389)
	at picocli.CommandLine.call(CommandLine.java:2665)
	at com.glencoesoftware.roitool.Main.main(Main.java:78)
Caused by: Ice.SocketException
    error = 0
	at IceInternal.AsyncResultI.__wait(AsyncResultI.java:276)
	at Ice.ObjectPrxHelperBase.end_ice_isA(ObjectPrxHelperBase.java:310)
	at Ice.ObjectPrxHelperBase.ice_isA(ObjectPrxHelperBase.java:92)
	at Ice.ObjectPrxHelperBase.ice_isA(ObjectPrxHelperBase.java:69)
	at Ice.ObjectPrxHelperBase.checkedCastImpl(ObjectPrxHelperBase.java:2810)
	at Ice.ObjectPrxHelperBase.checkedCastImpl(ObjectPrxHelperBase.java:2770)
	at Glacier2.RouterPrxHelper.checkedCast(RouterPrxHelper.java:1787)
	at omero.client.getRouter(client.java:889)
	at omero.client.createSession(client.java:810)
	at ome.formats.OMEROMetadataStoreClient.initialize(OMEROMetadataStoreClient.java:695)
	at ome.formats.OMEROMetadataStoreClient.initialize(OMEROMetadataStoreClient.java:666)
	at ome.formats.OMEROMetadataStoreClient.initialize(OMEROMetadataStoreClient.java:640)
	at ome.formats.OMEROMetadataStoreClient.initialize(OMEROMetadataStoreClient.java:615)
	at com.glencoesoftware.roitool.OMEOMEROConverter.initialize(OMEOMEROConverter.java:89)
	at com.glencoesoftware.roitool.OMEROCommand.createConverter(OMEROCommand.java:89)
	at com.glencoesoftware.roitool.Import.call(Import.java:63)
	at com.glencoesoftware.roitool.Import.call(Import.java:31)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1853)
	... 9 more
Caused by: java.net.SocketException: Network is unreachable
	at sun.nio.ch.Net.connect0(Native Method)
	at sun.nio.ch.Net.connect(Net.java:482)
	at sun.nio.ch.Net.connect(Net.java:474)
	at sun.nio.ch.SocketChannelImpl.connect(SocketChannelImpl.java:647)
	at IceInternal.Network.doConnect(Network.java:382)
	at IceInternal.StreamSocket.<init>(StreamSocket.java:28)
	at IceSSL.ConnectorI.connect(ConnectorI.java:27)
	at IceInternal.OutgoingConnectionFactory$ConnectCallback.nextConnector(OutgoingConnectionFactory.java:1101)
	at IceInternal.OutgoingConnectionFactory$ConnectCallback.access$100(OutgoingConnectionFactory.java:868)
	at IceInternal.OutgoingConnectionFactory.getConnection(OutgoingConnectionFactory.java:569)
	at IceInternal.OutgoingConnectionFactory.access$800(OutgoingConnectionFactory.java:14)
	at IceInternal.OutgoingConnectionFactory$ConnectCallback.getConnection(OutgoingConnectionFactory.java:1048)
	at IceInternal.OutgoingConnectionFactory$ConnectCallback.connectors(OutgoingConnectionFactory.java:932)
	at IceInternal.EndpointHostResolver$1.run(EndpointHostResolver.java:103)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```