### PR TITLE
Don't let image metadata reading issues prevent ROI export

### DIFF
--- a/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
+++ b/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
@@ -333,6 +333,7 @@ public class OMEOMEROConverter {
                 "LEFT OUTER JOIN FETCH p.planeInfo " +
                 "LEFT OUTER JOIN FETCH l.illumination " +
                 "LEFT OUTER JOIN FETCH l.mode " +
+                "LEFT OUTER JOIN FETCH l.contrastMethod " +
                 "LEFT OUTER JOIN FETCH p.details.updateEvent " +
                 "LEFT OUTER JOIN FETCH c.details.updateEvent " +
                 "WHERE i.id = :id",

--- a/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
+++ b/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
@@ -262,8 +262,13 @@ public class OMEOMEROConverter {
         // translate Image, ROI, and annotation data from OMERO objects to OME objects
         // keeping the Image and annotation data makes it easier to use the OME-XML in
         // downstream applications
-        omeXmlService.convertMetadata(
-                new ImageMetadata(this::getLsid, images), xmlMeta);
+        try {
+            omeXmlService.convertMetadata(
+                    new ImageMetadata(this::getLsid, images), xmlMeta);
+        }
+        catch (Exception e) {
+            log.warn("Failed to fully convert image metadata", e);
+        }
         omeXmlService.convertMetadata(
                 new ROIMetadata(this::getLsid, orderedRois), xmlMeta);
         omeXmlService.convertMetadata(


### PR DESCRIPTION
As discussed earlier today. This can be tested with image 2001 on qupath-testing, which is artificial data with a `ContrastMethod` attribute added.

Without this change, exporting should throw `omero.UnloadedEntityException: Object unloaded:omero.model.ContrastMethodI@29ad44e3` and not actually export the ROI. With 1c96c08, the ROI should be exported successfully, but the same `omero.UnloadedEntityException` should be logged. With both commits here, the ROI should be exported successfully and there should be no exceptions logged.