### PR TITLE
Remove any Images from OME-XML before it is imported to OMERO

### DIFF
--- a/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
+++ b/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
@@ -43,7 +43,15 @@ import ome.specification.XMLWriter;
 import ome.system.Login;
 import ome.xml.meta.MetadataConverter;
 import ome.xml.meta.OMEXMLMetadataRoot;
+import ome.xml.model.Dataset;
+import ome.xml.model.Experiment;
+import ome.xml.model.Experimenter;
+import ome.xml.model.ExperimenterGroup;
+import ome.xml.model.Instrument;
 import ome.xml.model.OME;
+import ome.xml.model.Plate;
+import ome.xml.model.Project;
+import ome.xml.model.Screen;
 import omero.ServerError;
 import omero.api.IConfigPrx;
 import omero.model.Annotation;
@@ -164,12 +172,7 @@ public class OMEOMEROConverter {
         OMEXMLMetadata xmlMeta;
         try {
             xmlMeta = omeXmlService.createOMEXMLMetadata(xml);
-
-            OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) xmlMeta.getRoot();
-            List<ome.xml.model.Image> images = root.copyImageList();
-            for (ome.xml.model.Image img : images) {
-                root.removeImage(img);
-            }
+            removeExtraMetadata(xmlMeta);
 
             log.info("Converting to OMERO metadata");
             MetadataConverter.convertMetadata(xmlMeta, target);
@@ -421,6 +424,51 @@ public class OMEOMEROConverter {
         if (this.target != null)
         {
             this.target.logout();
+        }
+    }
+
+    /**
+     * Remove everything apart from ROIs and StructuredAnnotations.
+     * Image, Plate, Dataset, Experiment, etc. will all be removed
+     * before sending to OMERO.
+     */
+    private void removeExtraMetadata(OMEXMLMetadata xmlMeta) {
+        OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) xmlMeta.getRoot();
+        List<ome.xml.model.Image> images = root.copyImageList();
+        for (ome.xml.model.Image img : images) {
+            root.removeImage(img);
+        }
+        List<Project> projects = root.copyProjectList();
+        for (Project p : projects) {
+            root.removeProject(p);
+        }
+        List<Dataset> datasets = root.copyDatasetList();
+        for (Dataset d : datasets) {
+            root.removeDataset(d);
+        }
+        List<Plate> plates = root.copyPlateList();
+        for (Plate p : plates) {
+            root.removePlate(p);
+        }
+        List<Experiment> experiments = root.copyExperimentList();
+        for (Experiment e : experiments) {
+            root.removeExperiment(e);
+        }
+        List<Experimenter> experimenters = root.copyExperimenterList();
+        for (Experimenter e : experimenters) {
+            root.removeExperimenter(e);
+        }
+        List<ExperimenterGroup> experimenterGroups = root.copyExperimenterGroupList();
+        for (ExperimenterGroup e : experimenterGroups) {
+            root.removeExperimenterGroup(e);
+        }
+        List<Screen> screens = root.copyScreenList();
+        for (Screen s : screens) {
+            root.removeScreen(s);
+        }
+        List<Instrument> instruments = root.copyInstrumentList();
+        for (Instrument i : instruments) {
+            root.removeInstrument(i);
         }
     }
 

--- a/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
+++ b/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
@@ -47,6 +47,7 @@ import ome.xml.model.Dataset;
 import ome.xml.model.Experiment;
 import ome.xml.model.Experimenter;
 import ome.xml.model.ExperimenterGroup;
+import ome.xml.model.Folder;
 import ome.xml.model.Instrument;
 import ome.xml.model.OME;
 import ome.xml.model.Plate;
@@ -469,6 +470,10 @@ public class OMEOMEROConverter {
         List<Instrument> instruments = root.copyInstrumentList();
         for (Instrument i : instruments) {
             root.removeInstrument(i);
+        }
+        List<Folder> folders = root.copyFolderList();
+        for (Folder f : folders) {
+            root.removeFolder(f);
         }
     }
 

--- a/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
+++ b/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
@@ -42,6 +42,7 @@ import loci.formats.services.OMEXMLService;
 import ome.specification.XMLWriter;
 import ome.system.Login;
 import ome.xml.meta.MetadataConverter;
+import ome.xml.meta.OMEXMLMetadataRoot;
 import ome.xml.model.OME;
 import omero.ServerError;
 import omero.api.IConfigPrx;
@@ -163,6 +164,13 @@ public class OMEOMEROConverter {
         OMEXMLMetadata xmlMeta;
         try {
             xmlMeta = omeXmlService.createOMEXMLMetadata(xml);
+
+            OMEXMLMetadataRoot root = (OMEXMLMetadataRoot) xmlMeta.getRoot();
+            List<ome.xml.model.Image> images = root.copyImageList();
+            for (ome.xml.model.Image img : images) {
+                root.removeImage(img);
+            }
+
             log.info("Converting to OMERO metadata");
             MetadataConverter.convertMetadata(xmlMeta, target);
             log.info("ROI count: {}", xmlMeta.getROICount());


### PR DESCRIPTION
Using 0.2.5 and any OME-XML that includes a populated `Image`, attempting to import to OMERO should result in an exception such as:

```
Exception in thread "main" picocli.CommandLine$ExecutionException: Error while calling command (com.glencoesoftware.roitool.Import@4cf4d528): java.lang.NullPointerException
	at picocli.CommandLine.executeUserObject(CommandLine.java:1862)
	at picocli.CommandLine.access$1100(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2255)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2249)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2213)
	at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:2073)
	at picocli.CommandLine.parseWithHandlers(CommandLine.java:2454)
	at picocli.CommandLine.parseWithHandler(CommandLine.java:2389)
	at picocli.CommandLine.call(CommandLine.java:2665)
	at com.glencoesoftware.roitool.Main.main(Main.java:78)
Caused by: java.lang.NullPointerException
	at ome.formats.model.PixelsProcessor.process(PixelsProcessor.java:136)
	at ome.formats.OMEROMetadataStoreClient.postProcess(OMEROMetadataStoreClient.java:1849)
	at com.glencoesoftware.roitool.OMEOMEROConverter.importRoisFromFile(OMEOMEROConverter.java:173)
	at com.glencoesoftware.roitool.Import.call(Import.java:71)
	at com.glencoesoftware.roitool.Import.call(Import.java:31)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1853)
	... 9 more
```

This can in particular happen with OME-XML that was exported from OMERO using ome-omero-roitool.

With this change, importing the same OME-XML that failed with 0.2.5 should be successful. Importing OME-XML that does not include an `Image` should continue to work as expected.

Once we're happy with this and it's merged, we can make a 0.2.6 release to include this fix.