### PR TITLE
Always export all displayorder-less rois

### DIFF
--- a/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
+++ b/src/main/java/com/glencoesoftware/roitool/OMEOMEROConverter.java
@@ -227,7 +227,6 @@ public class OMEOMEROConverter {
             allAnnotations.addAll(currentAnnotations);
         }
 
-        boolean foundIndex = false;
         for (final Annotation ann : allAnnotations) {
             if (ann instanceof XmlAnnotation && ann.getNs() != null &&
                 ann.getNs().getValue().equals(PATHVIEWER_NS))
@@ -257,15 +256,14 @@ public class OMEOMEROConverter {
                         orderedRois.add(null);
                     }
                 }
-                foundIndex = true;
                 break;
             }
         }
-        if (!foundIndex) {
-            for (Roi r : rois) {
-                if (!Mask.class.isAssignableFrom(r.getShape(0).getClass())) {
-                    orderedRois.add(r);
-                }
+        ArrayList<Roi> missedRois = new ArrayList<Roi>(rois);
+        missedRois.removeAll(orderedRois);
+        for (Roi r : missedRois) {
+            if (!Mask.class.isAssignableFrom(r.getShape(0).getClass())) {
+                orderedRois.add(r);
             }
         }
 


### PR DESCRIPTION
I found that for some images, roitool export would skip some rois. It turned out that, for whatever reason, the missing rois didn't have the `displayorder` annotation. The logic in `exportRoisToFile` was applying the displayorder for rois that had it, but then skipping the other rois entirely. This change reworks the logic to ensure those skipped rois are appended to the end of the list for export.